### PR TITLE
feat: add full FieldAdapter system (radio, select, value types)

### DIFF
--- a/examples/demo.html
+++ b/examples/demo.html
@@ -1,28 +1,306 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+  <style>
+  /* Global layout */
+  body {
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: #102543;           /* bleu foncé, moins "noir" */
+    color: #E9EEF4;               /* texte global clair */
+    margin: 0;
+    padding: 2rem;
+    line-height: 1.5;
+  }
+
+  h1 {
+    text-align: center;
+    color: #E9EEF4;
+    margin-bottom: 1.5rem;
+    font-weight: 600;
+  }
+
+  /* Cards (fieldsets) */
+  fieldset {
+    border: 1px solid #C3CFDD;    /* bordure claire, bleutée */
+    padding: 1.2rem;
+    margin-bottom: 1.5rem;
+    border-radius: 8px;
+    background: #418beb2c;          /* card très claire, légèrement bleutée */
+    color: #ffffffdd;               /* texte plus foncé à l'intérieur des cards */
+  }
+
+  legend {
+    padding: 0 0.4rem;
+    font-weight: 600;
+    color: #fdf000;               
+  }
+  fieldset p {
+    margin-bottom: 1rem;
+  }
+
+  /* Inputs */
+  input,
+  textarea,
+  select {
+    width: 100%;
+    max-width: 420px;
+    padding: 0.45rem 0.6rem;
+    margin-top: 0.3rem;
+    background: #FFFFFF;          /* fond blanc comme tu le veux */
+    color: #0C161D;               /* texte sombre */
+    border: 1px solid #C3CFDD;    /* bordure claire */
+    border-radius: 4px;
+    outline: none;
+    box-sizing: border-box;
+  }
+
+  input:focus,
+  textarea:focus,
+  select:focus {
+    border-color: #1B2A38;        /* bleu secondaire en focus */
+    box-shadow: 0 0 0 1px #1B2A38;
+  }
+
+  /* Submit button */
+  button[type="submit"] {
+    background: #1B2A38;          /* bouton bleu foncé */
+    color: #FFFFFF;
+    border: none;
+    padding: 0.6rem 1.4rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-top: 1rem;
+  }
+
+  button[type="submit"]:hover {
+    background: #223449;
+  }
+
+  button[type="submit"]:active {
+    background: #152131;
+  }
+</style>
+
   <meta charset="utf-8">
   <title>Savior – Demo</title>
 </head>
 <body>
   <h1>Savior – Demo</h1>
 
-  <p>Write some text, then refresh the page. Savior should restore your draft.</p>
+  <p>
+    Write in the fields below, toggle some controls, then refresh the page.<br>
+    Savior should restore the supported fields as we add adapters.
+  </p>
 
   <form data-savior="demo-form">
-    <p>
-      <label>
-        Email<br>
-        <input name="email" type="email" autocomplete="off">
-      </label>
-    </p>
+    <!-- Text-like fields -->
+    <fieldset>
+      <legend>Text fields</legend>
 
-    <p>
-      <label>
-        Message<br>
-        <textarea name="message" rows="5" cols="40"></textarea>
-      </label>
-    </p>
+      <p>
+        <label>
+          Text<br>
+          <input name="text" type="text" autocomplete="off">
+        </label>
+      </p>
+
+      <p>
+        <label>
+          Email<br>
+          <input name="email" type="email" autocomplete="off">
+        </label>
+      </p>
+
+      <p>
+        <label>
+          Search<br>
+          <input name="search" type="search" autocomplete="off">
+        </label>
+      </p>
+
+      <p>
+        <label>
+          URL<br>
+          <input name="url" type="url" autocomplete="off">
+        </label>
+      </p>
+
+      <p>
+        <label>
+          Telephone<br>
+          <input name="tel" type="tel" autocomplete="off">
+        </label>
+      </p>
+
+      <p>
+        <label>
+          Message (textarea)<br>
+          <textarea name="message" rows="4" cols="40"></textarea>
+        </label>
+      </p>
+    </fieldset>
+
+    <!-- Checkbox -->
+    <fieldset>
+      <legend>Checkbox</legend>
+
+      <p>
+        <label>
+          Subscribe to newsletter
+          <input name="subscribe" type="checkbox">
+        </label>
+      </p>
+
+      <p>
+        <label>
+          Accept terms
+          <input name="acceptTerms" type="checkbox">
+        </label>
+      </p>
+    </fieldset>
+
+    <!-- Radio -->
+    <fieldset>
+      <legend>Radio buttons</legend>
+
+      <p>Preferred contact method:</p>
+
+      <p>
+        <label>
+          <input type="radio" name="contactMethod" value="email">
+          Email
+        </label>
+      </p>
+
+      <p>
+        <label>
+          <input type="radio" name="contactMethod" value="phone">
+          Phone
+        </label>
+      </p>
+
+      <p>
+        <label>
+          <input type="radio" name="contactMethod" value="none">
+          None
+        </label>
+      </p>
+    </fieldset>
+
+    <!-- Select -->
+    <fieldset>
+      <legend>Select</legend>
+
+      <p>
+        <label>
+          Single select (country)<br>
+          <select name="country">
+            <option value="">-- Choose --</option>
+            <option value="ca">Canada</option>
+            <option value="us">United States</option>
+            <option value="fr">France</option>
+          </select>
+        </label>
+      </p>
+
+      <p>
+        <label>
+          Multi select (interests)<br>
+          <select name="interests" multiple size="4">
+            <option value="frontend">Frontend</option>
+            <option value="backend">Backend</option>
+            <option value="devops">DevOps</option>
+            <option value="design">Design</option>
+          </select>
+        </label>
+      </p>
+    </fieldset>
+
+    <!-- Number / Range / Date / Time -->
+    <fieldset>
+      <legend>Number / Range / Date / Time</legend>
+
+      <p>
+        <label>
+          Age (number)<br>
+          <input name="age" type="number" min="0" max="120">
+        </label>
+      </p>
+
+      <p>
+        <label>
+          Satisfaction (range)<br>
+          <input name="satisfaction" type="range" min="0" max="10">
+        </label>
+      </p>
+
+      <p>
+        <label>
+          Date<br>
+          <input name="date" type="date">
+        </label>
+      </p>
+
+      <p>
+        <label>
+          Time<br>
+          <input name="time" type="time">
+        </label>
+      </p>
+
+      <p>
+        <label>
+          Date &amp; time (local)<br>
+          <input name="datetimeLocal" type="datetime-local">
+        </label>
+      </p>
+
+      <p>
+        <label>
+          Month<br>
+          <input name="month" type="month">
+        </label>
+      </p>
+
+      <p>
+        <label>
+          Week<br>
+          <input name="week" type="week">
+        </label>
+      </p>
+    </fieldset>
+
+    <!-- Color -->
+    <fieldset>
+      <legend>Color</legend>
+
+      <p>
+        <label>
+          Favorite color<br>
+          <input name="favoriteColor" type="color" value="#8C5A2B">
+        </label>
+      </p>
+    </fieldset>
+
+    <!-- Fields not meant to be saved -->
+    <fieldset>
+      <legend>Fields not saved by Savior (for now)</legend>
+
+      <p>
+        <label>
+          Password (will NOT be saved)<br>
+          <input name="password" type="password" autocomplete="off">
+        </label>
+      </p>
+
+      <p>
+        <label>
+          File (cannot be restored programmatically)<br>
+          <input name="resume" type="file">
+        </label>
+      </p>
+    </fieldset>
 
     <p>
       <button type="submit">Envoyer</button>
@@ -39,4 +317,3 @@
   </script>
 </body>
 </html>
-

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -7,7 +7,7 @@
 <body>
   <h1>Savior – Demo</h1>
 
-  <p>Tape du texte, puis rafraîchis la page. Savior doit restaurer ton brouillon.</p>
+  <p>Write some text, then refresh the page. Savior should restore your draft.</p>
 
   <form data-savior="demo-form">
     <p>

--- a/src/core/savior-core.js
+++ b/src/core/savior-core.js
@@ -88,12 +88,20 @@ export class SaviorCore {
       const fieldName = element.name;
       if (!fieldName) continue;
 
+      // On ne sauvegarde pas les mots de passe
       if (element.type === 'password') continue;
 
       const adapter = getFieldAdapterForElement(element);
       if (!adapter) continue;
 
-      fields[fieldName] = adapter.readValue(element);
+      const value = adapter.readValue(element);
+
+      // Convention: undefined = "rien à sauver" (utile pour les radios non cochées)
+      if (value === undefined) {
+        continue;
+      }
+
+      fields[fieldName] = value;
     }
 
     const draft = {

--- a/src/core/savior-core.js
+++ b/src/core/savior-core.js
@@ -1,7 +1,12 @@
-// Core logic for Savior (debounce, tracking fields, restore, etc.)
-// Storage mechanism will be provided via a driver.
+// src/core/savior-core.js
+
+import { getFieldAdapterForElement } from '../fields/FieldAdapterRegistry.js';
+
 // Core autosave logic for Savior.
-// Depends on a driver exposing: save(formId, draft), load(formId), clear(formId).
+// Depends on a driver exposing:
+//   save(formId, draft),
+//   load(formId),
+//   clear(formId)
 
 export class SaviorCore {
   constructor(options) {
@@ -18,7 +23,7 @@ export class SaviorCore {
   attachToForm(formElement) {
     const formId = this.getFormId(formElement);
     if (!formId) {
-      console.warn('[Savior] Form without data-savior or id, skipping.', formElement);
+      console.warn('[Savior] Form without data-savior or id — skipping.', formElement);
       return;
     }
 
@@ -40,14 +45,19 @@ export class SaviorCore {
     if (!storedDraft || !storedDraft.fields) return;
 
     const elements = formElement.elements;
-    for (let index = 0; index < elements.length; index++) {
-      const element = elements[index];
+
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i];
       const fieldName = element.name;
       if (!fieldName) continue;
 
-      if (Object.prototype.hasOwnProperty.call(storedDraft.fields, fieldName)) {
-        element.value = storedDraft.fields[fieldName];
-      }
+      if (!(fieldName in storedDraft.fields)) continue;
+
+      const adapter = getFieldAdapterForElement(element);
+      if (!adapter) continue;
+
+      const savedValue = storedDraft.fields[fieldName];
+      adapter.writeValue(element, savedValue);
     }
   }
 
@@ -56,10 +66,10 @@ export class SaviorCore {
 
     const scheduleSave = () => {
       if (saveTimeoutId !== null) {
-        window.clearTimeout(saveTimeoutId);
+        clearTimeout(saveTimeoutId);
       }
 
-      saveTimeoutId = window.setTimeout(() => {
+      saveTimeoutId = setTimeout(() => {
         this.saveForm(formElement, formId);
         saveTimeoutId = null;
       }, this.saveDelayMs);
@@ -73,21 +83,23 @@ export class SaviorCore {
     const fields = {};
     const elements = formElement.elements;
 
-    for (let index = 0; index < elements.length; index++) {
-      const element = elements[index];
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i];
       const fieldName = element.name;
       if (!fieldName) continue;
 
-      // On ne sauvegarde pas les mots de passe
       if (element.type === 'password') continue;
 
-      fields[fieldName] = element.value;
+      const adapter = getFieldAdapterForElement(element);
+      if (!adapter) continue;
+
+      fields[fieldName] = adapter.readValue(element);
     }
 
     const draft = {
-      formId: formId,
+      formId,
       timestampUtc: new Date().toISOString(),
-      fields: fields
+      fields
     };
 
     this.driver.save(formId, draft);

--- a/src/fields/CheckboxFieldAdapter.js
+++ b/src/fields/CheckboxFieldAdapter.js
@@ -1,0 +1,39 @@
+// src/fields/CheckboxFieldAdapter.js
+import { FieldAdapter } from './FieldAdapter.js';
+
+export class CheckboxFieldAdapter extends FieldAdapter {
+  /**
+   * @param {HTMLElement} element
+   * @returns {boolean}
+   */
+  canHandle(element) {
+    return (
+      element instanceof HTMLInputElement &&
+      element.type === 'checkbox'
+    );
+  }
+
+  /**
+   * Read the checked state of the checkbox.
+   *
+   * For now we store a simple boolean:
+   *   true  -> checked
+   *   false -> unchecked
+   *
+   * @param {HTMLInputElement} element
+   * @returns {boolean}
+   */
+  readValue(element) {
+    return !!element.checked;
+  }
+
+  /**
+   * Restore the checked state from a boolean.
+   *
+   * @param {HTMLInputElement} element
+   * @param {unknown} value
+   */
+  writeValue(element, value) {
+    element.checked = Boolean(value);
+  }
+}

--- a/src/fields/FieldAdapter.js
+++ b/src/fields/FieldAdapter.js
@@ -1,0 +1,32 @@
+// src/fields/FieldAdapter.js
+
+/**
+ * Base contract for all field adapters.
+ * Each adapter decides if it can handle a given element,
+ * and knows how to read/write the field value.
+ */
+export class FieldAdapter {
+  /**
+   * @param {HTMLElement} element
+   * @returns {boolean}
+   */
+  canHandle(element) {
+    return false;
+  }
+
+  /**
+   * @param {HTMLElement} element
+   * @returns {unknown}
+   */
+  readValue(element) {
+    throw new Error('readValue() not implemented');
+  }
+
+  /**
+   * @param {HTMLElement} element
+   * @param {unknown} value
+   */
+  writeValue(element, value) {
+    throw new Error('writeValue() not implemented');
+  }
+}

--- a/src/fields/FieldAdapterRegistry.js
+++ b/src/fields/FieldAdapterRegistry.js
@@ -1,15 +1,16 @@
 // src/fields/FieldAdapterRegistry.js
 import { TextFieldAdapter } from './TextFieldAdapter.js';
-// Tu ajouteras d'autres adapters ici plus tard
-// import { CheckboxFieldAdapter } from './CheckboxFieldAdapter.js';
-// import { RadioFieldAdapter } from './RadioFieldAdapter.js';
-// import { SelectFieldAdapter } from './SelectFieldAdapter.js';
+import { CheckboxFieldAdapter } from './CheckboxFieldAdapter.js';
+import { RadioFieldAdapter } from './RadioFieldAdapter.js';
+import { SelectFieldAdapter } from './SelectFieldAdapter.js';
+import { ValueFieldAdapter } from './ValueFieldAdapter.js';
 
 const defaultAdapters = [
   new TextFieldAdapter(),
-  // new CheckboxFieldAdapter(),
-  // new RadioFieldAdapter(),
-  // new SelectFieldAdapter(),
+  new CheckboxFieldAdapter(),
+  new RadioFieldAdapter(),
+  new SelectFieldAdapter(),
+  new ValueFieldAdapter()
 ];
 
 /**

--- a/src/fields/FieldAdapterRegistry.js
+++ b/src/fields/FieldAdapterRegistry.js
@@ -1,0 +1,43 @@
+// src/fields/FieldAdapterRegistry.js
+import { TextFieldAdapter } from './TextFieldAdapter.js';
+// Tu ajouteras d'autres adapters ici plus tard
+// import { CheckboxFieldAdapter } from './CheckboxFieldAdapter.js';
+// import { RadioFieldAdapter } from './RadioFieldAdapter.js';
+// import { SelectFieldAdapter } from './SelectFieldAdapter.js';
+
+const defaultAdapters = [
+  new TextFieldAdapter(),
+  // new CheckboxFieldAdapter(),
+  // new RadioFieldAdapter(),
+  // new SelectFieldAdapter(),
+];
+
+/**
+ * Returns the first adapter that can handle the given field element.
+ *
+ * @param {HTMLElement} element
+ * @param {FieldAdapter[]} [adapters]
+ * @returns {FieldAdapter|null}
+ */
+export function getFieldAdapterForElement(element, adapters = defaultAdapters) {
+  for (const adapter of adapters) {
+    try {
+      if (adapter.canHandle(element)) {
+        return adapter;
+      }
+    } catch (error) {
+      // Safety net: one bad adapter should not break everything
+      // You could log this in a debug mode.
+      continue;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Expose the default adapters array if you need to extend it at runtime.
+ */
+export function getDefaultFieldAdapters() {
+  return defaultAdapters;
+}

--- a/src/fields/RadioFieldAdapter.js
+++ b/src/fields/RadioFieldAdapter.js
@@ -1,0 +1,54 @@
+// src/fields/RadioFieldAdapter.js
+import { FieldAdapter } from './FieldAdapter.js';
+
+export class RadioFieldAdapter extends FieldAdapter {
+  /**
+   * @param {HTMLElement} element
+   * @returns {boolean}
+   */
+  canHandle(element) {
+    return (
+      element instanceof HTMLInputElement &&
+      element.type === 'radio'
+    );
+  }
+
+  /**
+   * Read selected value for a radio group.
+   *
+   * Convention:
+   * - If this radio is NOT checked => return undefined (nothing to save)
+   * - If it is checked           => return its value (string)
+   *
+   * @param {HTMLInputElement} element
+   * @returns {string|undefined}
+   */
+  readValue(element) {
+    if (!element.checked) {
+      // Don't overwrite existing value for this name
+      return undefined;
+    }
+
+    // Default to "on" if no explicit value is set
+    return element.value ?? 'on';
+  }
+
+  /**
+   * Restore radio group state.
+   *
+   * Called for every radio with the same name.
+   * Only the one whose value matches the savedValue will become checked.
+   *
+   * @param {HTMLInputElement} element
+   * @param {unknown} savedValue
+   */
+  writeValue(element, savedValue) {
+    if (typeof savedValue !== 'string') {
+      element.checked = false;
+      return;
+    }
+
+    element.checked = (element.value === savedValue);
+  }
+}
+

--- a/src/fields/SelectFieldAdapter.js
+++ b/src/fields/SelectFieldAdapter.js
@@ -1,0 +1,47 @@
+// src/fields/SelectFieldAdapter.js
+import { FieldAdapter } from './FieldAdapter.js';
+
+export class SelectFieldAdapter extends FieldAdapter {
+
+  canHandle(element) {
+    return element instanceof HTMLSelectElement;
+  }
+
+  /**
+   * Read selected value(s):
+   * - single select => string
+   * - multiple select => array of strings
+   * - none selected => undefined
+   */
+  readValue(element) {
+    if (element.multiple) {
+      const selected = Array.from(element.selectedOptions).map(opt => opt.value);
+      return selected.length > 0 ? selected : undefined;
+    }
+
+    const value = element.value;
+    return value ? value : undefined;
+  }
+
+  /**
+   * Restore selected value(s):
+   * - single select => select.value = savedValue
+   * - multiple select => mark matching options as selected
+   */
+  writeValue(element, savedValue) {
+    if (element.multiple) {
+      // Expecting an array
+      if (!Array.isArray(savedValue)) return;
+
+      for (const option of element.options) {
+        option.selected = savedValue.includes(option.value);
+      }
+      return;
+    }
+
+    // Single select
+    if (typeof savedValue === 'string') {
+      element.value = savedValue;
+    }
+  }
+}

--- a/src/fields/TextFieldAdapter.js
+++ b/src/fields/TextFieldAdapter.js
@@ -1,0 +1,47 @@
+// src/fields/TextFieldAdapter.js
+import { FieldAdapter } from './FieldAdapter.js';
+
+export class TextFieldAdapter extends FieldAdapter {
+  /**
+   * @param {HTMLElement} element
+   * @returns {boolean}
+   */
+  canHandle(element) {
+    if (!(element instanceof HTMLInputElement) && !(element instanceof HTMLTextAreaElement)) {
+      return false;
+    }
+
+    // TextInput-like types
+    const textLikeTypes = [
+      'text',
+      'search',
+      'email',
+      'url',
+      'tel'
+    ];
+
+    // <textarea> has no "type" property worth checking
+    if (element instanceof HTMLTextAreaElement) {
+      return true;
+    }
+
+    // For <input>, type must be one of the text-like ones
+    return textLikeTypes.includes(element.type);
+  }
+
+  /**
+   * @param {HTMLInputElement|HTMLTextAreaElement} element
+   * @returns {string}
+   */
+  readValue(element) {
+    return element.value ?? '';
+  }
+
+  /**
+   * @param {HTMLInputElement|HTMLTextAreaElement} element
+   * @param {string} value
+   */
+  writeValue(element, value) {
+    element.value = typeof value === 'string' ? value : '';
+  }
+}

--- a/src/fields/ValueFieldAdapter.js
+++ b/src/fields/ValueFieldAdapter.js
@@ -1,0 +1,57 @@
+// src/fields/ValueFieldAdapter.js
+import { FieldAdapter } from './FieldAdapter.js';
+
+export class ValueFieldAdapter extends FieldAdapter {
+  /**
+   * This adapter handles "value-based" input types that are not
+   * covered by TextFieldAdapter / CheckboxFieldAdapter / RadioFieldAdapter.
+   *
+   * Supported types:
+   * - number
+   * - range
+   * - date
+   * - time
+   * - datetime-local
+   * - month
+   * - week
+   * - color
+   */
+  canHandle(element) {
+    if (!(element instanceof HTMLInputElement)) {
+      return false;
+    }
+
+    const supportedTypes = [
+      'number',
+      'range',
+      'date',
+      'time',
+      'datetime-local',
+      'month',
+      'week',
+      'color'
+    ];
+
+    return supportedTypes.includes(element.type);
+  }
+
+  /**
+   * For these inputs, we simply store the string value.
+   *
+   * @param {HTMLInputElement} element
+   * @returns {string}
+   */
+  readValue(element) {
+    return element.value ?? '';
+  }
+
+  /**
+   * Restore the stored value as-is.
+   *
+   * @param {HTMLInputElement} element
+   * @param {unknown} value
+   */
+  writeValue(element, value) {
+    element.value = typeof value === 'string' ? value : '';
+  }
+}


### PR DESCRIPTION
This PR introduces the full FieldAdapter system into Savior, extending field compatibility and formalizing the architecture for future drivers and field types.

## Added
- `RadioFieldAdapter` — handles radio groups cleanly using the `undefined` convention.
- `SelectFieldAdapter` — supports both single-select and multi-select modes.
- `ValueFieldAdapter` — generic adapter for inputs using `.value` (number, range, date, time, datetime-local, month, week, color).

## Updated
- `FieldAdapterRegistry` to register all adapters in priority order.
- `SaviorCore.saveForm()` to respect the `undefined` convention for fields that should not overwrite existing values (mainly for radio groups).
- `demo.html` — expanded with all input types + updated styling.

## Result
Savior now supports:
- text-like inputs  
- textarea  
- checkbox  
- radio  
- select (single and multiple)  
- all “value-based” form inputs  

This represents nearly complete browser form compatibility for v0.2.

## Notes
- Password and file inputs remain intentionally unsupported.
- Architecture is now cleanly extensible for future drivers (e.g., IndexedDB).

## Checklist
- [x] No breaking changes to existing text field behavior
- [x] Adapters tested manually in the demo page
- [x] All supported field types restore correctly after refresh
- [x] Password and file inputs remain excluded by design
- [x] Code follows project structure (`src/core`, `src/fields`, `src/drivers`)
- [x] Ready for merge into `main`

